### PR TITLE
README uses relative links for images so they come from local repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,32 +7,32 @@ Feel free to fork and extend the pinouts. Pull requests are welcome!
 
 ## Arduino Uno R3
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Uno%20R3%20Pinout.png" width="800">
+![Arduino-Uno-R3](Arduino%20Uno%20R3%20Pinout.png)
 
 ## Arduino Uno R2
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Uno%20R2%20Pinout.png" width="800">
+![Arduino-Uno-R2](Arduino%20Uno%20R2%20Pinout.png)
 
 ## Arduino Uno
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Uno%20Pinout.png" width="800">
+![Arduino-Uno](Arduino%20Uno%20Pinout.png)
 
 ## Arduino Uno SMD
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Uno%20SMD%20Pinout.png" width="800">
+![Arduino-Uno-SMD](Arduino%20Uno%20SMD%20Pinout.png)
 
 ## Arduino Pro
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Pro%20Pinout.png" width="800">
+![Arduino-Pro](Arduino%20Pro%20Pinout.png)
 
 ## Arduino Leonardo
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Leonardo%20Pinout.png" width="800">
+![Arduino-Leonardo](Arduino%20Leonardo%20Pinout.png)
 
 ## Arduino Micro
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Micro%20Pinout.png" width="800">
+![Arduino-Micro](Arduino%20Micro%20Pinout.png)
 
 ## Arduino Ethernet
 
-<img src="https://rawgithub.com/Bouni/Arduino-Pinout/master/Arduino%20Ethernet%20Pinout.svg" width="800">
+![Arduino-Ethernet](Arduino%20Ethernet%20Pinout.png)


### PR DESCRIPTION
This modifies the README to use relative links for the images so that the images come from the local repository rather than the one in Bouni.
The down side is that the images cannot be scaled but at least on my machine and browser, they seem to look the same size as the scaled images.
You can see this pull request combined with the leonardo fixes by looking at my branch: leonardo-fixes-N-relative-README